### PR TITLE
Update docs renaming Expressjs to Express.js

### DIFF
--- a/docs/overview/application.md
+++ b/docs/overview/application.md
@@ -47,7 +47,7 @@ ExpressoTS will prevent you to do that as there are no listeners to handle incom
 
 ## Application class
 
-The Application class offers a way of creating and configuring the server, passing **[Expressjs middlewares](https://expressjs.com/en/guide/writing-middleware.html)** or other middlewares upon server creation.
+The Application class offers a way of creating and configuring the server, passing **[Express.js middlewares](https://expressjs.com/en/guide/writing-middleware.html)** or other middlewares upon server creation.
 
 Application class definition
 

--- a/docs/overview/first-steps.md
+++ b/docs/overview/first-steps.md
@@ -363,7 +363,7 @@ Once the application is up and running, you can access it by navigating to `http
 
 ## Note
 
-ExpressoTS is a versatile framework that is not bound to any specific platform or technology. Leveraging popular Node.js libraries like InversifyJS and ExpressJS, it is designed to be lightweight, modular, customizable, and easy to use. Developers can expand the framework's capabilities by creating new providers that can be incorporated into their applications.
+ExpressoTS is a versatile framework that is not bound to any specific platform or technology. Leveraging popular Node.js libraries like InversifyJS and Express.js, it is designed to be lightweight, modular, customizable, and easy to use. Developers can expand the framework's capabilities by creating new providers that can be incorporated into their applications.
 
 We are currently working on building the project RoadMap and plan to add support for other popular Node.js HTTP frameworks, like Fastify and Koa, to the platform. Additionally, as we move towards the future, we intend to eliminate some of the dependencies that are currently part of the framework's core, and replacing them with our own custom implementations to make the framework more secure, reliable and efficient.
 

--- a/docs/overview/intro.md
+++ b/docs/overview/intro.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Introduction
 
 ExpressoTS is a TypeScript lightweight framework for building scalable, readable and maintainable server-side applications.
-The framework provides a level of abstraction on top of common HTTP server framework **[Expressjs](https://expressjs.com/)** exposing their API's directly to the developer. This provides freedom and brings to the developer a tool that is well known and easy to use.
+The framework provides a level of abstraction on top of common HTTP server framework **[Express.js](https://expressjs.com/)** exposing their API's directly to the developer. This provides freedom and brings to the developer a tool that is well known and easy to use.
 
 ## Philosophy
 

--- a/docs/overview/render.md
+++ b/docs/overview/render.md
@@ -4,9 +4,9 @@ sidebar_position: 16
 
 # Render
 
-**[Expressjs](https://expressjs.com/en/5x/api.html#res.render)** offers a `render` method to render a view and send the rendered HTML string to the client.
+**[Express.js](https://expressjs.com/en/5x/api.html#res.render)** offers a `render` method to render a view and send the rendered HTML string to the client.
 
-In ExpressoTS as we do support Expressjs, we also support the `render` capability offered by the HTTP response object.
+In ExpressoTS as we do support Express.js, we also support the `render` capability offered by the HTTP response object.
 
 ExpressoTS implements a basic support for render engines in the `Application` class. At the moment the number of renders supported is limited to Handlebars.
 

--- a/i18n/pt/docusaurus-plugin-content-docs/current/overview/application.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/overview/application.md
@@ -47,7 +47,7 @@ O ExpressoTS irá impedir que você faça isso, pois não há ouvintes para lida
 
 ## Classe Aplication
 
-A classe Application oferece uma forma de criar e configurar o servidor, passando **[Expressjs middlewares](https://expressjs.com/en/guide/writing-middleware.html)** ou outro middlewares durante a criação do servidor.
+A classe Application oferece uma forma de criar e configurar o servidor, passando **[Express.js middlewares](https://expressjs.com/en/guide/writing-middleware.html)** ou outro middlewares durante a criação do servidor.
 
 Definição da classe Aplication
 

--- a/i18n/pt/docusaurus-plugin-content-docs/current/overview/first-steps.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/overview/first-steps.md
@@ -361,7 +361,7 @@ Uma vez que a aplicação está em execução, você pode acessá-la navegando p
 
 ## Resumo
 
-ExpressoTS é um framework versátil que não está vinculado a nenhuma plataforma ou tecnologia específica. Aproveitando bibliotecas populares do Node.js como InversifyJS e ExpressJS, ele é projetado para ser leve, modular, personalizável e fácil de usar. Os desenvolvedores podem expandir as capacidades do framework criando novos provedores que podem ser incorporados em suas aplicações.
+ExpressoTS é um framework versátil que não está vinculado a nenhuma plataforma ou tecnologia específica. Aproveitando bibliotecas populares do Node.js como InversifyJS e Express.js, ele é projetado para ser leve, modular, personalizável e fácil de usar. Os desenvolvedores podem expandir as capacidades do framework criando novos provedores que podem ser incorporados em suas aplicações.
 
 Atualmente, estamos trabalhando na construção da RoadMap do projeto e planejamos adicionar suporte para outros populares frameworks HTTP do Node.js, como o Fastify e o Koa, à plataforma. Além disso, à medida que avançamos para o futuro, pretendemos eliminar algumas das dependências que atualmente fazem parte do núcleo do framework, como IoC e decoradores.
 

--- a/i18n/pt/docusaurus-plugin-content-docs/current/overview/render.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/overview/render.md
@@ -4,9 +4,9 @@ sidebar_position: 16
 
 # Renderizacão
 
-**[Expressjs](https://expressjs.com/en/5x/api.html#res.render)** oferece um método `render` para renderizar uma visualização e enviar a sequência HTML renderizada para o cliente.
+**[Express.js](https://expressjs.com/en/5x/api.html#res.render)** oferece um método `render` para renderizar uma visualização e enviar a sequência HTML renderizada para o cliente.
 
-No ExpressoTS, como oferecemos suporte ao Expressjs, também oferecemos suporte à capacidade de renderização oferecida pelo objeto de resposta HTTP.
+No ExpressoTS, como oferecemos suporte ao Express.js, também oferecemos suporte à capacidade de renderização oferecida pelo objeto de resposta HTTP.
 
 O ExpressoTS implementa um suporte básico para mecanismos de renderização na classe `Application`. No momento, o número de mecanismos de renderização suportados é limitado ao Handlebars.
 


### PR DESCRIPTION
Following their GitHub organization's description

> **Express.js**: the fast, unopinionated, minimalist web framework for node

https://github.com/expressjs